### PR TITLE
feat(components): remove multiple export support

### DIFF
--- a/src/core/components/ComponentHandler.ts
+++ b/src/core/components/ComponentHandler.ts
@@ -86,10 +86,11 @@ export abstract class ComponentHandler<
 			let value = this.loaderStrategy.load(filepath);
 			if (isThenable(value)) value = await value;
 
-			for (const component of this.loaderStrategy.resolve(this, value)) {
-				const instance: TComponent = Reflect.construct(component, []);
-				promises.push(this.load(instance, filepath));
-			}
+			const component = this.loaderStrategy.resolve(this, value);
+			if (!component) continue;
+
+			const instance: TComponent = Reflect.constructor(component, []);
+			promises.push(this.load(instance, filepath));
 		}
 
 		await Promise.all(promises);

--- a/src/core/components/strategies/CommonJsLoaderStrategy.ts
+++ b/src/core/components/strategies/CommonJsLoaderStrategy.ts
@@ -7,8 +7,8 @@ import type { LoaderStrategy } from './LoaderStrategy';
 import { extname } from 'path';
 
 /**
- * A loader strategy that uses the CommonJS module system, supporting multiple
- * default and named exports in addition to hot-reloading.
+ * A loader strategy for the CommonJS module system, supporting both default and
+ * named exports in addition to hot-reloading.
  */
 export class CommonJsLoaderStrategy<T extends Component> implements LoaderStrategy<T> {
 	private readonly supportedExtensions = new Set(['.js', '.ts']);
@@ -24,14 +24,14 @@ export class CommonJsLoaderStrategy<T extends Component> implements LoaderStrate
 		return mod;
 	}
 
-	public *resolve(handler: ComponentHandler<T>, value: unknown) {
+	public resolve(handler: ComponentHandler<T>, value: unknown) {
 		// Handle `module.exports` / `export =`.
-		if (isClass(value) && isSubclassOf(value, handler.classType)) yield value;
+		if (isClass(value) && isSubclassOf(value, handler.classType)) return value;
 
 		// Handle named exports, including default exports.
 		if (!isObject(value)) return;
 		for (const namedExport of Object.values(value)) {
-			if (isClass(namedExport) && isSubclassOf(namedExport, handler.classType)) yield namedExport;
+			if (isClass(namedExport) && isSubclassOf(namedExport, handler.classType)) return namedExport;
 		}
 	}
 

--- a/src/core/components/strategies/LoaderStrategy.ts
+++ b/src/core/components/strategies/LoaderStrategy.ts
@@ -26,13 +26,13 @@ export interface LoaderStrategy<T extends Component> {
 	load(filepath: string): unknown;
 
 	/**
-	 * Resolves components from a value.
+	 * Resolves a component from a value.
 	 *
 	 * @param handler - Handler which is loading this component.
-	 * @param value - Value to resolve components from.
-	 * @returns An iterator over the resolved components.
+	 * @param value - Value to resolve a component from.
+	 * @returns The resolved component, or `undefined` if it does not exist.
 	 */
-	resolve(handler: ComponentHandler<T>, value: unknown): IterableIterator<Constructor<T>>;
+	resolve(handler: ComponentHandler<T>, value: unknown): Constructor<T> | undefined;
 
 	/**
 	 * Unloads a file.


### PR DESCRIPTION
This PR removes multiple export support from the component loader.
This decision was mostly made due to the fact that multiple exports are a pretty rare use-case and the fact that a single file exports multiple components means that reloading just one of them actually causes all of them to be reloaded.